### PR TITLE
Send notifications on the main thread.

### DIFF
--- a/GCNetworkReachability.m
+++ b/GCNetworkReachability.m
@@ -390,9 +390,11 @@ static void GCNetworkReachabilityCallbackWithBlock(SCNetworkReachabilityRef __un
 static void GCNetworkReachabilityCallback(SCNetworkReachabilityRef __unused target, SCNetworkReachabilityFlags flags, void *info)
 {
     GCNetworkReachabilityStatus status = GCNetworkReachabilityStatusForFlags(flags);
-    [[NSNotificationCenter defaultCenter] postNotificationName:kGCNetworkReachabilityDidChangeNotification
-                                                        object:(__bridge GCNetworkReachability *)info
-                                                      userInfo:@{kGCNetworkReachabilityStatusKey : @(status)}];
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [[NSNotificationCenter defaultCenter] postNotificationName:kGCNetworkReachabilityDidChangeNotification
+                                                            object:(__bridge GCNetworkReachability *)info
+                                                          userInfo:@{kGCNetworkReachabilityStatusKey : @(status)}];
+    });
     
     GCNetworkReachabilityPrintFlags(flags);
 }


### PR DESCRIPTION
In this case I think it's bad practice to send out notifications on a background thread. Usually this kind of notification will trigger some UI update which must be on the main thread.
